### PR TITLE
Atualiza framework e dependências para versão 1.0.0

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -6,14 +6,14 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <InvariantGlobalization>false</InvariantGlobalization>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
-        <Version>0.0.1</Version>
+        <Version>1.0.0</Version>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0"/>
         <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0"/>
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1"/>
-        <PackageReference Include="IATec.Shared.Api" Version="0.1.1" />
+        <PackageReference Include="IATec.Shared.Api" Version="1.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0"/>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.0" />

--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IATec.Shared.Application" Version="0.1.1" />
+        <PackageReference Include="IATec.Shared.Application" Version="1.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0"/>
     </ItemGroup>
 

--- a/src/CrossCutting/CrossCutting.csproj
+++ b/src/CrossCutting/CrossCutting.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="IATec.Shared.Behaviors" Version="0.1.1" />
+        <PackageReference Include="IATec.Shared.Behaviors" Version="1.0.0" />
         <PackageReference Include="MediatR" Version="12.4.1" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0"/>
     </ItemGroup>

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="FluentResults" Version="3.16.0" />
         <PackageReference Include="FluentValidation" Version="11.10.0" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
-        <PackageReference Include="IATec.Shared.Domain" Version="0.2.3" />
+        <PackageReference Include="IATec.Shared.Domain" Version="1.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Atualização do framework de destino no `Api.csproj` para `net8.0`. Incremento da versão do projeto principal para `1.0.0`, indicando um marco de maturidade. Atualização das dependências internas (`IATec.Shared.*`) para a versão `1.0.0` em todos os projetos (`Api`, `Application`, `CrossCutting`, `Domain`), garantindo alinhamento e compatibilidade.